### PR TITLE
Always allow extraction on non-sided inventories

### DIFF
--- a/src/mrtjp/core/inventory/invwrapper.scala
+++ b/src/mrtjp/core/inventory/invwrapper.scala
@@ -259,7 +259,7 @@ abstract class InvWrapper(val inv:IInventory)
     protected def canExtractItem(slot:Int, item:ItemStack):Boolean =
     {
         if (internalMode) return true
-        if (side < 0) inv.isItemValidForSlot(slot, item) else sidedInv.canExtractItem(slot, item, side)
+        side < 0 || sidedInv.canExtractItem(slot, item, side)
     }
 }
 


### PR DESCRIPTION
Some mods lock the output slots to prevent stuff going in, but doing the old check invalidates pulling from the output.
